### PR TITLE
Improve setup-env script to allow selection machine and distro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+build*/
 *~
 *.pyc
 *.pyo

--- a/layers/meta-testdistro/conf/local.conf.sample
+++ b/layers/meta-testdistro/conf/local.conf.sample
@@ -77,7 +77,7 @@ DISTRO ?= "testdistro"
 # you can build the SDK packages for architectures other than the machine you are
 # running the build on (i.e. building i686 packages on an x86_64 host).
 # Supported values are i686 and x86_64
-SDKMACHINE ?= "i686"
+SDKMACHINE ?= "x86_64"
 
 #
 # Extra image configuration defaults

--- a/layers/meta-testdistro/conf/local.conf.sample
+++ b/layers/meta-testdistro/conf/local.conf.sample
@@ -1,10 +1,84 @@
+#
+# This file is your local configuration file and is where all local user settings
+# are placed. The comments in this file give some guide to the options a new user
+# to the system might want to change but pretty much any configuration option can
+# be set in this file. More adventurous users can look at local.conf.extended
+# which contains other examples of configuration which can be placed in this file
+# but new users likely won't need any of them initially.
+#
+# Lines starting with the '#' character are commented out and in some cases the
+# default values are provided as comments to show people example syntax. Enabling
+# the option is a question of removing the # character and making any change to the
+# variable as required.
+
+#
+# Machine Selection
+#
+# You need to select a specific machine to target the build with. There are a selection
+# of emulated machines available which can boot and run in the QEMU emulator:
+#
 MACHINE ??= "qemux86"
+
+#
+# Default policy config
+#
+# The distribution setting controls which policy settings are used as defaults.
+# The default value is fine for general Yocto project use, at least initially.
+# Ultimately when creating custom policy, people will likely end up subclassing 
+# these defaults.
+#
 DISTRO ?= "testdistro"
-#DL_DIR ?= "/archive/distros/test-distro/downloads"
-#SSTATE_DIR ?= "/archive/distros/test-distro/sstate-cache"
+
+#
+# Where to place downloads
+#
+# During a first build the system will download many different source code tarballs
+# from various upstream projects. This can take a while, particularly if your network
+# connection is slow. These are all stored in DL_DIR. When wiping and rebuilding you
+# can preserve this directory to speed up this part of subsequent builds. This directory
+# is safe to share between multiple builds on the same machine too.
+#
+# The default is a downloads directory under TOPDIR which is the build directory.
+#
+#DL_DIR ?= "${TOPDIR}/downloads"
+
+#
+# Where to place shared-state files
+#
+# BitBake has the capability to accelerate builds based on previously built output.
+# This is done using "shared state" files which can be thought of as cache objects
+# and this option determines where those files are placed.
+#
+# You can wipe out TMPDIR leaving this directory intact and the build would regenerate
+# from these files if no changes were made to the configuration. If changes were made
+# to the configuration, only shared state files where the state was still valid would
+# be used (done using checksums).
+#
+# The default is a sstate-cache directory under TOPDIR.
+#
+#SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
+
+#
+# Where to place the build output
+#
+# This option specifies where the bulk of the building work should be done and
+# where BitBake should place its temporary files and output. Keep in mind that
+# this includes the extraction and compilation of many applications and the toolchain
+# which can use Gigabytes of hard disk space.
+#
+# The default is a tmp directory under TOPDIR.
+#
 #TMPDIR = "${TOPDIR}/tmp"
-SDKMACHINE ?= "x86_64"
-EXTRA_IMAGE_FEATURES ?= "empty-root-password allow-empty-password allow-root-login"
+
+#
+# SDK target architecture
+#
+# This variable specifies the architecture to build SDK items for and means
+# you can build the SDK packages for architectures other than the machine you are
+# running the build on (i.e. building i686 packages on an x86_64 host).
+# Supported values are i686 and x86_64
+SDKMACHINE ?= "i686"
+
 #
 # Extra image configuration defaults
 #
@@ -27,7 +101,7 @@ EXTRA_IMAGE_FEATURES ?= "empty-root-password allow-empty-password allow-root-log
 # There are other application targets that can be used here too, see
 # meta/classes/image.bbclass and meta/classes/core-image.bbclass for more details.
 # We default to enabling the debugging tweaks.
-#EXTRA_IMAGE_FEATURES = "debug-tweaks"
+EXTRA_IMAGE_FEATURES = "debug-tweaks"
 
 #
 # Additional image features
@@ -116,6 +190,19 @@ BB_DISKMON_DIRS = "\
 #PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 #ASSUME_PROVIDED += "libsdl-native"
 
+#
+# Hash Equivalence
+#
+# Enable support for automatically running a local hash equivalence server and
+# instruct bitbake to use a hash equivalence aware signature generator. Hash
+# equivalence improves reuse of sstate by detecting when a given sstate
+# artifact can be reused as equivalent, even if the current task hash doesn't
+# match the one that generated the artifact.
+#
+# A shared hash equivalent server can be set with "<HOSTNAME>:<PORT>" format
+#
+#BB_HASHSERVE = "auto"
+#BB_SIGNATURE_HANDLER = "OEEquivHash"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if

--- a/setup-env
+++ b/setup-env
@@ -109,10 +109,7 @@ if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$MACHINE" ]; then
 fi
 
 if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$DISTRO" ]; then
-    usage
-    echo -e "ERROR: You must set DISTRO when creating a new build directory."
-    clean_up
-    return 1
+    DISTRO="testdistro"
 fi
 
 (cd $CWD; git submodule sync > /dev/null 2>&1)

--- a/setup-env
+++ b/setup-env
@@ -119,6 +119,9 @@ if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$DISTRO" ]; then
     return 1
 fi
 
+(cd $CWD; git submodule sync > /dev/null 2>&1)
+(cd $CWD; git submodule status | grep '^-' | awk '{print $2}' | xargs git submodule update --init --)
+
 # Allow for multiple layer sets,
 # default just "layers"
 if [ "x$BMETA" = "x" ]; then

--- a/setup-env
+++ b/setup-env
@@ -4,53 +4,201 @@ if [ -z "$ZSH_NAME"] && [ "x$0" = "x./setup-env" ]; then
     exit 1
 fi
 
+PROGNAME="setup-env"
+
 if [ -n "$BASH_SOURCE" ]; then
-    OEROOT="`dirname $BASH_SOURCE`"
+    CWD="`dirname $BASH_SOURCE`"
 elif [ -n "$ZSH_SOURCE"]; then
-    OEROOT="`dirname $0`"
+    CWD="`dirname $0`"
 else
-    OEROOT="`pwd`"
+    CWD="`pwd`"
 fi
+
 if [ -n "$BBSERVER" ]; then
     unset BBSERVER
 fi
-if [ "x$1" = "x" ]; then
-    BDIR="build"
-else
-    BDIR="$1"
-fi
-if [ -e "$BDIR" ]; then
-    BDIR=`readlink -f "$BDIR"`
-    if [ ! -d "$BDIR" ]; then
-	echo "Usage: setup-env [dirname]"
-	return 1
+
+usage()
+{
+    echo -e "
+Usage: MACHINE=<machine> DISTRO=<distro> source $PROGNAME <build-dir>
+Usage:                                   source $PROGNAME <build-dir>
+    <machine>    machine name
+    <distro>     distro name
+    <build-dir>  build directory
+The first usage is for creating a new build directory. In this case, the
+script creates the build directory <build-dir>, configures it for the
+specified <machine> and <distro>, and prepares the calling shell for running
+bitbake on the build directory.
+The second usage is for using an existing build directory. In this case,
+the script prepares the calling shell for running bitbake on the build
+directory <build-dir>. The build directory configuration is unchanged.
+"
+
+    ls layers/*/conf/machine/*.conf > /dev/null 2>&1
+    ls layers/meta-testdistro/conf/distro/*.conf > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo -e "
+Supported machines: `echo; ls layers/*/conf/machine/*.conf \
+| sed s/\.conf//g | sed -r 's/^.+\///' | xargs -I% echo -e "\t%"`
+Supported Tegra test distros: `echo; ls layers/meta-testdistro/conf/distro/*.conf \
+| sed s/\.conf//g | sed -r 's/^.+\///' | xargs -I% echo -e "\t%"`
+Examples:
+- To create a new Yocto build directory:
+  $ MACHINE=jetson-tx2 DISTRO=testdistro source $PROGNAME build
+- To use an existing Yocto build directory:
+  $ source $PROGNAME build
+"
     fi
-else
-    mkdir -p "$BDIR"
-    BDIR=`readlink -f "$BDIR"`
+}
+
+clean_up()
+{
+   unset LIST_MACHINES VALID_MACHINE
+   unset CWD TEMPLATES SHORTOPTS LONGOPTS ARGS PROGNAME
+   unset generated_config updated
+   unset MACHINE SDKMACHINE DISTRO OEROOT TEMPLATECONF BBPATH
+}
+
+# get command line options
+SHORTOPTS="h"
+LONGOPTS="help"
+
+ARGS=$(getopt --options $SHORTOPTS  \
+  --longoptions $LONGOPTS --name $PROGNAME -- "$@" )
+# Print the usage menu if invalid options are specified
+if [ $? != 0 -o $# -lt 1 ]; then
+   usage && clean_up
+   return 1
 fi
+
+eval set -- "$ARGS"
+while true;
+do
+    case $1 in
+        -h|--help)
+           usage
+           clean_up
+           return 0
+           ;;
+        --)
+           shift
+           break
+           ;;
+    esac
+done
+
+if [ "$(whoami)" = "root" ]; then
+    echo "ERROR: do not use the BSP as root. Exiting..."
+fi
+
+if [ ! -e $1/conf/local.conf ]; then
+    build_dir_setup_enabled="true"
+else
+    build_dir_setup_enabled="false"
+fi
+
+if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$MACHINE" ]; then
+    usage
+    echo -e "ERROR: You must set MACHINE when creating a new build directory."
+    clean_up
+    return 1
+fi
+
+if [ -z "$SDKMACHINE" ]; then
+    SDKMACHINE='x86_64'
+fi
+
+if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$DISTRO" ]; then
+    usage
+    echo -e "ERROR: You must set DISTRO when creating a new build directory."
+    clean_up
+    return 1
+fi
+
 # Allow for multiple layer sets,
 # default just "layers"
 if [ "x$BMETA" = "x" ]; then
     BMETA="layers"
 fi
-OEROOT=`readlink -f "$OEROOT/$BMETA"`
+OEROOT=`readlink -f "$CWD/$BMETA"`
 export OEROOT
-export BITBAKEDIR="$OEROOT/bitbake"
-. $OEROOT/scripts/oe-buildenv-internal && \
-    $OEROOT/scripts/oe-setup-builddir && \
-    [ -n "$BUILDDIR" ] && cd $BUILDDIR
-TEMPLATECONF=`cat $BUILDDIR/conf/templateconf.cfg`
+
+export TEMPLATECONF=${TEMPLATECONF:-$OEROOT/meta-testdistro/conf}
+
+. $OEROOT/openembedded-core/oe-init-build-env $CWD/$1 > /dev/null
+
+# if conf/local.conf not generated, no need to go further
+if [ ! -e conf/local.conf ]; then
+    clean_up && return 1
+fi
+
+generated_config=
+if [ "$build_dir_setup_enabled" = "true" ]; then
+
+    # Change settings according environment
+    sed -e "s,MACHINE ??=.*,MACHINE ??= '$MACHINE',g" \
+        -e "s,SDKMACHINE ?=.*,SDKMACHINE ?= '$SDKMACHINE',g" \
+        -e "s,DISTRO ?=.*,DISTRO ?= '$DISTRO',g" \
+        -e "s,PACKAGE_CLASSES ?=.*,PACKAGE_CLASSES ?= '$PACKAGE_CLASSES',g" \
+        -i conf/local.conf
+
+    for s in $HOME/.oe $HOME/.yocto; do
+        if [ -e $s/site.conf ]; then
+            echo "Linking $s/site.conf to conf/site.conf"
+            ln -s $s/site.conf conf
+        fi
+    done
+
+    generated_config=1
+fi
+
+cat <<EOF
+Welcome to the meta-tegra test distribution.
+
+The Yocto Project has extensive documentation about OE including a
+reference manual which can be found at:
+    http://yoctoproject.org/documentation
+For more information about OpenEmbedded see their website:
+    http://www.openembedded.org/
+
+You can now run 'bitbake <target>'
+Common targets are:
+    core-image-minimal
+    meta-toolchain
+    meta-toolchain-sdk
+    adt-installer
+    meta-ide-support
+EOF
+
+if [ -n "$generated_config" ]; then
+    cat <<EOF
+Your build environment has been configured with:
+    MACHINE=$MACHINE
+    SDKMACHINE=$SDKMACHINE
+    DISTRO=$DISTRO
+EOF
+else
+    echo "Your configuration files at $1 have not been touched."
+fi
+
+TDROOT=`readlink -f "$CWD/$BMETA"`
+export TDROOT
+
 if [ ! -f "$BUILDDIR/conf/site.conf" -a \
        -f "$OEROOT/$TEMPLATECONF/site.conf.sample" ]; then
     cp $OEROOT/$TEMPLATECONF/site.conf.sample $BUILDDIR/conf/site.conf
 fi
+
 if [ -d "$OEROOT/meta-testdistro/scripts" ]; then
     PATH="$OEROOT/meta-testdistro/scripts:$PATH"
     [ ! -e "$OEROOT/meta-testdistro/scripts/buildenv-host-gcc-check" ] || . "$OEROOT/meta-testdistro/scripts/buildenv-host-gcc-check"
 fi
+
 BB_ENV_EXTRAWHITE="GNUPGHOME DBUS_SESSION_BUS_ADDRESS AWS_CONFIG_FILE AWS_PROFILE AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SHARED_CREDENTIALS_FILE AWS_SESSION_TOKEN AWS_DEFAULT_REGION $BB_ENV_EXTRAWHITE"
-unset OEROOT BBPATH TEMPLATECONF BITBAKEDIR
+
 if [ "`umask | tail -c 2`" = "7" ]; then
     umask 0022
 fi
+
+clean_up

--- a/setup-env
+++ b/setup-env
@@ -58,7 +58,7 @@ clean_up()
    unset LIST_MACHINES VALID_MACHINE
    unset CWD TEMPLATES SHORTOPTS LONGOPTS ARGS PROGNAME
    unset generated_config updated
-   unset MACHINE SDKMACHINE DISTRO OEROOT TEMPLATECONF BBPATH TDROOT
+   unset MACHINE DISTRO OEROOT TEMPLATECONF BBPATH TDROOT
 }
 
 # get command line options
@@ -108,10 +108,6 @@ if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$MACHINE" ]; then
     return 1
 fi
 
-if [ -z "$SDKMACHINE" ]; then
-    SDKMACHINE='x86_64'
-fi
-
 if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$DISTRO" ]; then
     usage
     echo -e "ERROR: You must set DISTRO when creating a new build directory."
@@ -146,9 +142,7 @@ if [ "$build_dir_setup_enabled" = "true" ]; then
 
     # Change settings according environment
     sed -e "s,MACHINE ??=.*,MACHINE ??= '$MACHINE',g" \
-        -e "s,SDKMACHINE ?=.*,SDKMACHINE ?= '$SDKMACHINE',g" \
         -e "s,DISTRO ?=.*,DISTRO ?= '$DISTRO',g" \
-        -e "s,PACKAGE_CLASSES ?=.*,PACKAGE_CLASSES ?= '$PACKAGE_CLASSES',g" \
         -i conf/local.conf
 
     for s in $HOME/.oe $HOME/.yocto; do
@@ -183,7 +177,6 @@ if [ -n "$generated_config" ]; then
     cat <<EOF
 Your build environment has been configured with:
     MACHINE=$MACHINE
-    SDKMACHINE=$SDKMACHINE
     DISTRO=$DISTRO
 EOF
 else

--- a/setup-env
+++ b/setup-env
@@ -5,6 +5,8 @@ if [ -z "$ZSH_NAME"] && [ "x$0" = "x./setup-env" ]; then
 fi
 
 PROGNAME="setup-env"
+DISTRO_DEFAULT="testdistro"
+BUILDDIR_DEFAULT="build"
 
 if [ -n "$BASH_SOURCE" ]; then
     CWD="`dirname $BASH_SOURCE`"
@@ -21,18 +23,25 @@ fi
 usage()
 {
     cat <<EOF
-Usage: MACHINE=<machine> DISTRO=<distro> source $PROGNAME <build-dir>
-Usage:                                   source $PROGNAME <build-dir>
-    <machine>    machine name
-    <distro>     distro name
-    <build-dir>  build directory
+Usage: source $PROGNAME --machine <MACHINE> [<options>] [<BUILDDIR>]
+Usage: source $PROGNAME [<BUILDDIR>]
+
+Options:
+    -h, --help         Print this usage message
+    -m, --machine      Build MACHINE name
+    -d, --distro       Build DISTRO name (default '${DISTRO_DEFAULT}')
+
+Arguments:
+    BUILDDIR           Location of BUILDDIR (default '${BUILDDIR_DEFAULT}')
+
 The first usage is for creating a new build directory. In this case, the
-script creates the build directory <build-dir>, configures it for the
-specified <machine> and <distro>, and prepares the calling shell for running
+script creates the build directory <BUILDDIR>, configures it for the
+specified <MACHINE> and <DISTRO>, and prepares the calling shell for running
 bitbake on the build directory.
+
 The second usage is for using an existing build directory. In this case,
 the script prepares the calling shell for running bitbake on the build
-directory <build-dir>. The build directory configuration is unchanged.
+directory <BUILDDIR>. The build directory configuration is unchanged.
 
 EOF
     ls layers/*/conf/machine/*.conf > /dev/null 2>&1
@@ -43,11 +52,13 @@ Supported machines: `echo; ls layers/*/conf/machine/*.conf \
 | sed s/\.conf//g | sed -r 's/^.+\///' | xargs -I% echo -e "\t%"`
 Supported Tegra test distros: `echo; ls layers/meta-testdistro/conf/distro/*.conf \
 | sed s/\.conf//g | sed -r 's/^.+\///' | xargs -I% echo -e "\t%"`
+
 Examples:
 - To create a new Yocto build directory:
-  $ MACHINE=jetson-tx2 DISTRO=testdistro source $PROGNAME build
+  $ source $PROGNAME --machine jetson-tx2 --distro testdistro build-testdistro
+
 - To use an existing Yocto build directory:
-  $ source $PROGNAME build
+  $ source $PROGNAME build-testdistro
 
 EOF
     fi
@@ -62,13 +73,13 @@ clean_up()
 }
 
 # get command line options
-SHORTOPTS="h"
-LONGOPTS="help"
+SHORTOPTS="hm:d:b:"
+LONGOPTS="help,machine,distro"
 
 ARGS=$(getopt --options $SHORTOPTS  \
   --longoptions $LONGOPTS --name $PROGNAME -- "$@" )
 # Print the usage menu if invalid options are specified
-if [ $? != 0 -o $# -lt 1 ]; then
+if [ $? != 0 ]; then
    usage && clean_up
    return 1
 fi
@@ -77,15 +88,11 @@ eval set -- "$ARGS"
 while true;
 do
     case $1 in
-        -h|--help)
-           usage
-           clean_up
-           return 0
-           ;;
-        --)
-           shift
-           break
-           ;;
+        -h | --help)       usage; clean_up; return 0 ;;
+        -m | --machine)    MACHINE="$2"; shift; shift;;
+        -d | --distro)     DISTRO="$2"; shift; shift;;
+        -- )               shift; break ;;
+        * )                break ;;
     esac
 done
 
@@ -95,7 +102,9 @@ if [ $(id -u) -eq 0 ]; then
     return 1
 fi
 
-if [ ! -e $1/conf/local.conf ]; then
+BUILDDIR="${1:-$BUILDDIR_DEFAULT}"
+
+if [ ! -e $BUILDDIR/conf/local.conf ]; then
     build_dir_setup_enabled="true"
 else
     build_dir_setup_enabled="false"
@@ -109,7 +118,7 @@ if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$MACHINE" ]; then
 fi
 
 if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$DISTRO" ]; then
-    DISTRO="testdistro"
+    DISTRO=$DISTRO_DEFAULT
 fi
 
 (cd $CWD; git submodule sync > /dev/null 2>&1)
@@ -126,7 +135,7 @@ export OEROOT
 # we need the OEROOT path later, but it gets unset by oe-init-build-env
 TDROOT=$OEROOT
 
-. $OEROOT/openembedded-core/oe-init-build-env $CWD/$1 > /dev/null
+. $OEROOT/openembedded-core/oe-init-build-env $CWD/$BUILDDIR > /dev/null
 
 # if conf/local.conf not generated, no need to go further
 if ! [ -d "$BUILDDIR" -a -e $BUILDDIR/conf/local.conf ]; then
@@ -168,6 +177,7 @@ Common targets are:
     meta-toolchain-sdk
     adt-installer
     meta-ide-support
+
 EOF
 
 if [ -n "$generated_config" ]; then
@@ -175,9 +185,10 @@ if [ -n "$generated_config" ]; then
 Your build environment has been configured with:
     MACHINE=$MACHINE
     DISTRO=$DISTRO
+
 EOF
 else
-    echo "Your configuration files at $1 have not been touched."
+    echo "Your configuration files at $BUILDDIR have not been touched."
 fi
 
 # sets TEMPLATECONF

--- a/setup-env
+++ b/setup-env
@@ -133,7 +133,8 @@ TDROOT=$OEROOT
 . $OEROOT/openembedded-core/oe-init-build-env $CWD/$1 > /dev/null
 
 # if conf/local.conf not generated, no need to go further
-if [ ! -e conf/local.conf ]; then
+if ! [ -d "$BUILDDIR" -a -e $BUILDDIR/conf/local.conf ]; then
+    echo -e "ERROR: could not create build directory or local.conf"
     clean_up && return 1
 fi
 

--- a/setup-env
+++ b/setup-env
@@ -89,8 +89,10 @@ do
     esac
 done
 
-if [ "$(whoami)" = "root" ]; then
+if [ $(id -u) -eq 0 ]; then
     echo "ERROR: do not use the BSP as root. Exiting..."
+    clean_up
+    return 1
 fi
 
 if [ ! -e $1/conf/local.conf ]; then

--- a/setup-env
+++ b/setup-env
@@ -20,7 +20,7 @@ fi
 
 usage()
 {
-    echo -e "
+    cat <<EOF
 Usage: MACHINE=<machine> DISTRO=<distro> source $PROGNAME <build-dir>
 Usage:                                   source $PROGNAME <build-dir>
     <machine>    machine name
@@ -33,12 +33,12 @@ bitbake on the build directory.
 The second usage is for using an existing build directory. In this case,
 the script prepares the calling shell for running bitbake on the build
 directory <build-dir>. The build directory configuration is unchanged.
-"
 
+EOF
     ls layers/*/conf/machine/*.conf > /dev/null 2>&1
     ls layers/meta-testdistro/conf/distro/*.conf > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-        echo -e "
+        cat <<EOF
 Supported machines: `echo; ls layers/*/conf/machine/*.conf \
 | sed s/\.conf//g | sed -r 's/^.+\///' | xargs -I% echo -e "\t%"`
 Supported Tegra test distros: `echo; ls layers/meta-testdistro/conf/distro/*.conf \
@@ -48,7 +48,8 @@ Examples:
   $ MACHINE=jetson-tx2 DISTRO=testdistro source $PROGNAME build
 - To use an existing Yocto build directory:
   $ source $PROGNAME build
-"
+
+EOF
     fi
 }
 

--- a/setup-env
+++ b/setup-env
@@ -58,7 +58,7 @@ clean_up()
    unset LIST_MACHINES VALID_MACHINE
    unset CWD TEMPLATES SHORTOPTS LONGOPTS ARGS PROGNAME
    unset generated_config updated
-   unset MACHINE SDKMACHINE DISTRO OEROOT TEMPLATECONF BBPATH
+   unset MACHINE SDKMACHINE DISTRO OEROOT TEMPLATECONF BBPATH TDROOT
 }
 
 # get command line options
@@ -127,7 +127,8 @@ fi
 OEROOT=`readlink -f "$CWD/$BMETA"`
 export OEROOT
 
-export TEMPLATECONF=${TEMPLATECONF:-$OEROOT/meta-testdistro/conf}
+# we need the OEROOT path later, but it gets unset by oe-init-build-env
+TDROOT=$OEROOT
 
 . $OEROOT/openembedded-core/oe-init-build-env $CWD/$1 > /dev/null
 
@@ -185,17 +186,17 @@ else
     echo "Your configuration files at $1 have not been touched."
 fi
 
-TDROOT=`readlink -f "$CWD/$BMETA"`
-export TDROOT
+# sets TEMPLATECONF
+. $TDROOT/.templateconf
 
 if [ ! -f "$BUILDDIR/conf/site.conf" -a \
-       -f "$OEROOT/$TEMPLATECONF/site.conf.sample" ]; then
-    cp $OEROOT/$TEMPLATECONF/site.conf.sample $BUILDDIR/conf/site.conf
+       -f "$TDROOT/$TEMPLATECONF/site.conf.sample" ]; then
+    cp $TDROOT/$TEMPLATECONF/site.conf.sample $BUILDDIR/conf/site.conf
 fi
 
-if [ -d "$OEROOT/meta-testdistro/scripts" ]; then
-    PATH="$OEROOT/meta-testdistro/scripts:$PATH"
-    [ ! -e "$OEROOT/meta-testdistro/scripts/buildenv-host-gcc-check" ] || . "$OEROOT/meta-testdistro/scripts/buildenv-host-gcc-check"
+if [ -d "$TDROOT/meta-testdistro/scripts" ]; then
+    PATH="$TDROOT/meta-testdistro/scripts:$PATH"
+    [ ! -e "$TDROOT/meta-testdistro/scripts/buildenv-host-gcc-check" ] || . "$TDROOT/meta-testdistro/scripts/buildenv-host-gcc-check"
 fi
 
 BB_ENV_EXTRAWHITE="GNUPGHOME DBUS_SESSION_BUS_ADDRESS AWS_CONFIG_FILE AWS_PROFILE AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SHARED_CREDENTIALS_FILE AWS_SESSION_TOKEN AWS_DEFAULT_REGION $BB_ENV_EXTRAWHITE"


### PR DESCRIPTION
This change lays the groundwork for the support of multiple distros
that will eventually be contained within this repository.

It also makes the script a bit more user friendly and aids in the
discovery of different machine types and distro names.